### PR TITLE
Add feature to configure pool_size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in angus-remote.gemspec
 gemspec
 
-gem 'picasso-remote', :git => 'ssh://git@intranet.moove-it.com:8082/picasso-remote-client',
-                      :branch => 'legacy'
+gem 'picasso-remote', git: 'ssh://git@gerrit.moove-it.com:8082/picasso-remote-client',
+                      branch: 'legacy'
 
-gem 'picasso-sdoc', :git => 'ssh://git@intranet.moove-it.com:8082/picasso-sdoc'
+gem 'picasso-sdoc', git: 'ssh://git@gerrit.moove-it.com:8082/picasso-sdoc'

--- a/lib/angus/remote/client.rb
+++ b/lib/angus/remote/client.rb
@@ -16,7 +16,7 @@ module Angus
         api_url = api_url[0..-2] if api_url[-1] == '/'
 
         @connection = PersistentHTTP.new(
-          :pool_size    => 10,
+          :pool_size    => options['pool_size'] || 10,
           :pool_timeout => 10,
           :warn_timeout => 0.25,
           :force_retry  => false,


### PR DESCRIPTION
Add feature to configure pool_size in the "#PROJECT_ROOT/config/services.yml". The default value for pool_size is 10 if the property is not defined.

Example:

api_url: http://localhost:8081/service_name/api/0.2/
doc_url: http://localhost:8081/service_name/doc/0.2/
public_key: jRqn3tTRsVjRA0n3tTRA0n3tTRsVjRq
private_key: +vuaRqn3tTRsVjRA0n3tTRA0n3tTRsVjRq
pool_size: 15
